### PR TITLE
Add ButtonLink component

### DIFF
--- a/src/components/ButtonLink/ButtonLink.styles.ts
+++ b/src/components/ButtonLink/ButtonLink.styles.ts
@@ -1,0 +1,49 @@
+import type { ButtonLinkSize, ButtonLinkStyle, ButtonLinkState, ButtonLinkIconPosition } from './ButtonLink.types';
+import clsx from 'clsx';
+
+export default function getButtonLinkStyle(
+  size: ButtonLinkSize,
+  style: ButtonLinkStyle,
+  state: ButtonLinkState,
+  iconPosition?: ButtonLinkIconPosition,
+  fullWidth: boolean = false,
+) {
+  const isIconAlone = iconPosition === 'alone',
+    baseClasses = `transition-all duration-200 rounded-md flex items-center justify-center gap-1.5 ${fullWidth ? 'w-full' : ''}`;
+
+  const sizeClasses = {
+    sm: isIconAlone ? 'p-2' : 'px-2.5 py-1.5 text-sm',
+    md: isIconAlone ? 'p-2' : 'px-3 py-2 text-base',
+    lg: isIconAlone ? 'p-2' : 'px-4 py-3 text-lg',
+    xl: isIconAlone ? 'p-2' : 'px-5 py-4 text-2xl',
+  };
+
+  const iconSizeMap = {
+    sm: 18,
+    md: 20,
+    lg: 22,
+    xl: 24,
+  };
+
+  const styleClasses = {
+    primary: 'text-stone-50 bg-brown-500 border-2 border-brown-500',
+    secondary: 'text-brown-700 bg-brown-100 border-2 border-brown-100',
+    action: 'text-brown-500 border-2 border-brown-500',
+  };
+
+  const hoverClasses = {
+    primary: 'hover:bg-brown-400 hover:border-brown-400',
+    secondary: 'hover:bg-brown-200 hover:border-brown-200',
+    action: 'hover:bg-brown-100',
+  };
+
+  const stateClasses = {
+    enabled: clsx('cursor-pointer opacity-100', hoverClasses[style]),
+    disabled: 'cursor-not-allowed opacity-50',
+  };
+
+  const buttonLinkStyle = clsx(baseClasses, styleClasses[style], sizeClasses[size], stateClasses[state]),
+    iconSize = iconSizeMap[size];
+
+  return { buttonLinkStyle, iconSize };
+}

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -1,0 +1,34 @@
+import type { ButtonLinkProps } from './ButtonLink.types';
+import getButtonLinkStyle from './ButtonLink.styles';
+
+const Button = ({
+  label = 'Label',
+  ariaLabel = 'Default button',
+  size = 'md',
+  style = 'primary',
+  icon: Icon,
+  iconPosition = 'left',
+  state = 'enabled',
+  fullWidth = false,
+  href,
+}: ButtonLinkProps) => {
+  const disabled = state === 'disabled',
+    { buttonLinkStyle, iconSize } = getButtonLinkStyle(size, style, state, iconPosition, fullWidth);
+
+  return (
+    <a
+      href={disabled ? undefined : href}
+      onClick={disabled ? (e) => e.preventDefault() : undefined}
+      aria-label={ariaLabel}
+      aria-disabled={disabled}
+      className={buttonLinkStyle}
+    >
+      {Icon && iconPosition === 'left' && <Icon size={iconSize} data-testid="icon" />}
+      {iconPosition !== 'alone' && label}
+      {Icon && iconPosition === 'right' && <Icon size={iconSize} data-testid="icon" />}
+      {Icon && iconPosition === 'alone' && <Icon size={iconSize} data-testid="icon" />}
+    </a>
+  );
+};
+
+export default Button;

--- a/src/components/ButtonLink/ButtonLink.types.ts
+++ b/src/components/ButtonLink/ButtonLink.types.ts
@@ -1,0 +1,18 @@
+import type { LucideIcon } from 'lucide-react';
+
+export type ButtonLinkStyle = 'primary' | 'secondary' | 'action';
+export type ButtonLinkSize = 'sm' | 'md' | 'lg' | 'xl';
+export type ButtonLinkIconPosition = 'left' | 'right' | 'alone';
+export type ButtonLinkState = 'enabled' | 'disabled';
+
+export interface ButtonLinkProps {
+  label?: string;
+  ariaLabel?: string;
+  size?: ButtonLinkSize;
+  style?: ButtonLinkStyle;
+  icon?: LucideIcon;
+  fullWidth?: boolean;
+  iconPosition?: ButtonLinkIconPosition;
+  state?: ButtonLinkState;
+  href: string;
+}


### PR DESCRIPTION
## 📌 Description

This pull request introduces a new `ButtonLink` component, including its styles, functionality, and type definitions. The component is designed to be versatile, supporting various sizes, styles, states, and configurations for icons and labels. Below is a breakdown of the most important changes.

---

## 🔍 Related Issues

No related issues.

---

## ✨ Changes Made

### Component Implementation:

* [`src/components/ButtonLink/ButtonLink.tsx`](diffhunk://#diff-518c3872d31125a70c231c5a55634e59acd7de9b78c7c82723f740176fd963afR1-R34): Added the `ButtonLink` component, which renders an accessible anchor element with configurable properties like size, style, state, icon position, and full-width support. The component uses the `getButtonLinkStyle` function to dynamically generate styles based on props.

### Styling:

* [`src/components/ButtonLink/ButtonLink.styles.ts`](diffhunk://#diff-946862f9403706bb72822feabd06b4402493668d597d72de3629cf20bb10c01cR1-R49): Implemented the `getButtonLinkStyle` function to generate dynamic styles for the `ButtonLink` component. The styles include base classes, size-specific classes, hover effects, and state-based classes. It also maps icon sizes to button sizes for consistent design.

### Type Definitions:

* [`src/components/ButtonLink/ButtonLink.types.ts`](diffhunk://#diff-1e075043450bc0d2c820cddd75f7f1b12ba0f3acaa5beda78c6661c72f39cfe2R1-R18): Defined type definitions for `ButtonLink` props, including enums for size, style, state, and icon position. This ensures type safety and clear documentation for the component's API.

---

## ✅ Checklist

- [x] My code follows the project's coding standards and naming conventions
- [x] I have tested the changes locally and verified expected behavior
- [x] No new console warnings or errors
- [x] (If UI-related) I verified responsiveness on mobile and desktop
- [x] I updated or added documentation where necessary
- [x] The branch is up to date with target base branch

---

## 🚀 Additional Notes

N/A